### PR TITLE
feat(classroom): prevent sign renaming

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -3,6 +3,7 @@
 ## [Unreleased]
 
 ### Added
+- Implemented prevention of sign renaming within the classroom
 - Implemented question rotation system to prevent repetition
 - Added support for multiple languages (Russian, Hebrew, and English) in questions.yml
 - Implemented a system to slightly favor questions that haven't been asked in a long time

--- a/Project.astra.md
+++ b/Project.astra.md
@@ -1,0 +1,4 @@
+# Important notes
+
+- In this project we do not write tests
+- We are update Changelog.md and Todo.md after each codding step

--- a/Todo.md
+++ b/Todo.md
@@ -4,7 +4,7 @@ This file contains tasks, improvements, and features that are planned or need to
 
 ## High Priority
 
-- [ ] Prevent from renaming signs in the classroom
+- [x] Prevent from renaming signs in the classroom
 - [x] After pressing incorrect button all buttons became not active anymore
 - [ ] Implement inventory management system to lock player inventories during night/quiz time
 - [ ] Add sound effects for correct/incorrect quiz answers

--- a/src/main/java/org/h0x91b/mcTestAi1/events/EventListener.java
+++ b/src/main/java/org/h0x91b/mcTestAi1/events/EventListener.java
@@ -2,6 +2,7 @@ package org.h0x91b.mcTestAi1.events;
 
 import com.google.inject.Inject;
 import org.bukkit.Bukkit;
+import org.bukkit.ChatColor;
 import org.bukkit.Location;
 import org.bukkit.event.EventHandler;
 import org.bukkit.event.Listener;
@@ -9,6 +10,7 @@ import org.bukkit.event.block.BlockBreakEvent;
 import org.bukkit.event.player.PlayerJoinEvent;
 import org.bukkit.event.entity.PlayerDeathEvent;
 import org.bukkit.event.block.BlockPlaceEvent;
+import org.bukkit.event.block.SignChangeEvent;
 import org.h0x91b.mcTestAi1.managers.ClassroomManager;
 import org.h0x91b.mcTestAi1.managers.DayNightManager;
 import org.bukkit.plugin.java.JavaPlugin;
@@ -108,6 +110,18 @@ public class EventListener implements Listener {
             }
         } catch (Exception e) {
             plugin.getLogger().warning("Error handling PvP event: " + e.getMessage());
+        }
+    }
+
+    @EventHandler
+    public void onSignChange(SignChangeEvent event) {
+        Player player = event.getPlayer();
+        Location signLocation = event.getBlock().getLocation();
+
+        if (classroomManager.isClassroomBlock(signLocation)) {
+            event.setCancelled(true);
+            player.sendMessage(ChatColor.RED + "Изменение табличек в классной комнате запрещено!");
+            plugin.getLogger().info("Prevented sign change by " + player.getName() + " in classroom at " + signLocation);
         }
     }
 


### PR DESCRIPTION
- Add event listener for sign change events
- Check if sign is within classroom boundaries
- Cancel event and notify player if sign is in classroom