### PR TITLE
feat(quiz): add multilingual support

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -3,6 +3,7 @@
 ## [Unreleased]
 
 ### Added
+- Implemented language selection command (/language <russian|hebrew|english>)
 - Implemented randomization of answer order on quiz buttons
 - Implemented prevention of sign renaming within the classroom
 - Implemented question rotation system to prevent repetition
@@ -13,19 +14,27 @@
 - Added sound effects for correct and incorrect quiz answers
 
 ### Changed
+- Updated language command to be accessible without special permissions
+- Simplified language command usage for all players
+- Updated QuizManager to handle language changes during runtime
 - Refactored QuizManager to improve question selection and management
 - Updated question loading process to support multiple languages from questions.yml
 - Modified DayNightManager to handle more precise time announcements
 - Improved error handling and logging throughout the plugin
 - Updated Question class to handle randomized answer order
 - Updated Config class to load sound effect settings from config.yml
+- Modified language selection to immediately shuffle and restart the quiz when changed during night time
+- Updated LanguageCommand to provide more specific feedback based on day/night cycle
 
 ### Improved
+- Enhanced accessibility of language selection for quizzes
+- Enhanced multilingual support for quizzes
 - Enhanced quiz experience with better question variety and language support
 - Optimized question management to ensure all questions are used before repeating
 - Improved plugin stability and error resilience
 - Enhanced quiz randomization to prevent answer pattern recognition
 - Enhanced audio feedback for quiz participants with sound effects
+- Enhanced quiz experience by ensuring language changes take immediate effect during night time
 
 ### Fixed
 - Addressed issues with question repetition and randomization

--- a/Todo.md
+++ b/Todo.md
@@ -5,6 +5,9 @@ This file contains tasks, improvements, and features that are planned or need to
 ## High Priority
 
 - [ ] Implement client language detection using Player.getLocale() and send localized messages accordingly
+- [ ] Implement the quiz language selector in the Classroom (it should switch language)
+- [x] Implement the quiz language changer command /language <russian|hebrew|english>
+- [x] Ensure language changes immediately affect ongoing quizzes during night time
 - [x] Prevent from renaming signs in the classroom
 - [x] After pressing incorrect button all buttons became not active anymore
 - [ ] Implement inventory management system to lock player inventories during night/quiz time
@@ -17,7 +20,7 @@ This file contains tasks, improvements, and features that are planned or need to
 - [x] Implement a 3-second cooldown with button disappearance after an incorrect answer
 - [x] Add a 1-second cooldown with button disappearance after a correct answer
 - [x] Move all questions and answers from code to a YAML configuration file
-- [ ] Implement language selection support for Russian, Hebrew, and English
+- [x] Implement language selection support for Russian, Hebrew, and English
 - [x] Show earned time after each correct answer
 - [x] Optimize classroom cleanup process to occur only once at game start
 - [x] Improve quiz button setup and management

--- a/src/main/java/org/h0x91b/mcTestAi1/McTestAi1.java
+++ b/src/main/java/org/h0x91b/mcTestAi1/McTestAi1.java
@@ -12,6 +12,7 @@ import org.h0x91b.mcTestAi1.managers.ClassroomManager;
 import org.h0x91b.mcTestAi1.managers.DayNightManager;
 import org.h0x91b.mcTestAi1.managers.InventoryManager;
 import org.h0x91b.mcTestAi1.managers.QuizManager;
+import org.h0x91b.mcTestAi1.commands.LanguageCommand;
 import org.bukkit.Bukkit;
 import org.bukkit.entity.Entity;
 import org.bukkit.entity.ArmorStand;
@@ -37,6 +38,7 @@ public final class McTestAi1 extends JavaPlugin {
             binder.bind(InventoryManager.class).asEagerSingleton();
             binder.bind(EventListener.class).asEagerSingleton();
             binder.bind(ButtonClickListener.class).asEagerSingleton();
+            binder.bind(LanguageCommand.class).asEagerSingleton();
         });
 
         // Инициализация менеджеров
@@ -60,6 +62,10 @@ public final class McTestAi1 extends JavaPlugin {
         if (dayNightManager.isNight()) {
             quizManager.startQuiz();
         }
+
+        // Register the new language command
+        LanguageCommand languageCommand = injector.getInstance(LanguageCommand.class);
+        getCommand("language").setExecutor(languageCommand);
 
         getLogger().info("mcTestAi1 плагин загружен и готов отжигать!");
     }

--- a/src/main/java/org/h0x91b/mcTestAi1/commands/LanguageCommand.java
+++ b/src/main/java/org/h0x91b/mcTestAi1/commands/LanguageCommand.java
@@ -1,0 +1,60 @@
+package org.h0x91b.mcTestAi1.commands;
+
+import com.google.inject.Inject;
+import org.bukkit.ChatColor;
+import org.bukkit.command.Command;
+import org.bukkit.command.CommandExecutor;
+import org.bukkit.command.CommandSender;
+import org.bukkit.entity.Player;
+import org.h0x91b.mcTestAi1.managers.QuizManager;
+import org.h0x91b.mcTestAi1.managers.DayNightManager;
+
+import java.util.Arrays;
+import java.util.List;
+
+public class LanguageCommand implements CommandExecutor {
+    private final QuizManager quizManager;
+    private final DayNightManager dayNightManager;
+    private static final List<String> VALID_LANGUAGES = Arrays.asList("russian", "hebrew", "english");
+
+    @Inject
+    public LanguageCommand(QuizManager quizManager, DayNightManager dayNightManager) {
+        this.quizManager = quizManager;
+        this.dayNightManager = dayNightManager;
+    }
+
+    @Override
+    public boolean onCommand(CommandSender sender, Command command, String label, String[] args) {
+        if (!(sender instanceof Player)) {
+            sender.sendMessage(ChatColor.RED + "This command can only be used by players.");
+            return true;
+        }
+
+        Player player = (Player) sender;
+
+        if (args.length != 1) {
+            player.sendMessage(ChatColor.RED + "Usage: /language <russian|hebrew|english>");
+            return false;
+        }
+
+        String language = args[0].toLowerCase();
+        if (!VALID_LANGUAGES.contains(language)) {
+            player.sendMessage(ChatColor.RED + "Invalid language. Please choose russian, hebrew, or english.");
+            return false;
+        }
+
+        try {
+            quizManager.setLanguage(language);
+            if (dayNightManager.isNight()) {
+                player.sendMessage(ChatColor.GREEN + "Quiz language has been set to " + language + " and the quiz has been restarted.");
+            } else {
+                player.sendMessage(ChatColor.GREEN + "Quiz language has been set to " + language + " for the next night.");
+            }
+        } catch (Exception e) {
+            player.sendMessage(ChatColor.RED + "An error occurred while changing the language. Please try again.");
+            e.printStackTrace();
+        }
+
+        return true;
+    }
+}

--- a/src/main/java/org/h0x91b/mcTestAi1/managers/QuizManager.java
+++ b/src/main/java/org/h0x91b/mcTestAi1/managers/QuizManager.java
@@ -419,8 +419,15 @@ public class QuizManager {
     public void setLanguage(String language) {
         if (questions.containsKey(language)) {
             this.currentLanguage = language;
-            unusedQuestions = null;
+            resetQuestionPool();
             logger.info("Quiz language changed to: " + language);
+
+            // Check if it's night time and restart the quiz if necessary
+            if (dayNightManagerProvider.get().isNight()) {
+                logger.info("Restarting quiz with new language during night time");
+                cleanupQuiz();
+                startQuiz();
+            }
         } else {
             logger.warning("Attempted to set unsupported language: " + language);
         }

--- a/src/main/resources/plugin.yml
+++ b/src/main/resources/plugin.yml
@@ -8,5 +8,8 @@ commands:
   createroom:
     description: Creates a 10x10x5 room at height 200
     usage: /<command>
+  language:
+    description: Changes the quiz language
+    usage: /<command> <russian|hebrew|english>
 
 config: questions.yml


### PR DESCRIPTION
- Implement /language command to change quiz language
- Shuffle and restart quiz when language is changed during night
- Provide user feedback based on day/night cycle